### PR TITLE
feat: add cdk typescript stack with s3 bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+cdk.out/
+*.js
+*.d.ts
+*.js.map
+*.d.ts.map
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # learning-codex
+
+This project contains a simple AWS CDK application written in TypeScript.
+
+The CDK stack creates a single Amazon S3 bucket.
+
+## Useful commands
+
+* `npm install`     install dependencies
+* `npm run build`   compile TypeScript to JavaScript
+* `npm test`        run unit tests
+* `npx cdk synth`   emit the synthesized CloudFormation template
+* `npx cdk deploy`  deploy this stack to your default AWS account/region
+

--- a/bin/learning-codex.ts
+++ b/bin/learning-codex.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LearningCodexStack } from '../lib/learning-codex-stack';
+
+const app = new cdk.App();
+new LearningCodexStack(app, 'LearningCodexStack');
+

--- a/cdk.json
+++ b/cdk.json
@@ -1,0 +1,4 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/learning-codex.ts"
+}
+

--- a/lib/learning-codex-stack.ts
+++ b/lib/learning-codex-stack.ts
@@ -1,0 +1,12 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+
+export class LearningCodexStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    new s3.Bucket(this, 'LearningCodexBucket');
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "learning-codex",
+  "version": "0.1.0",
+  "bin": {
+    "learning-codex": "bin/learning-codex.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.4.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.120.0",
+    "constructs": "^10.3.0",
+    "source-map-support": "^0.5.21"
+  }
+}
+

--- a/test/learning-codex.test.ts
+++ b/test/learning-codex.test.ts
@@ -1,0 +1,11 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { LearningCodexStack } from '../lib/learning-codex-stack';
+
+test('S3 bucket created', () => {
+  const app = new cdk.App();
+  const stack = new LearningCodexStack(app, 'TestStack');
+  const template = Template.fromStack(stack);
+  template.resourceCountIs('AWS::S3::Bucket', 1);
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["bin/**/*.ts", "lib/**/*.ts", "test/**/*.ts"]
+}
+


### PR DESCRIPTION
## Summary
- initialize TypeScript AWS CDK app
- add stack that provisions a single S3 bucket
- include unit test and project configuration

## Testing
- `npm install` (fails: 403 Forbidden - cannot access registry)
- `npm run build` (fails: Cannot find module 'aws-cdk-lib')
- `npm test` (fails: jest not found)
- `npx cdk synth` (fails: 403 Forbidden - cannot access registry)


------
https://chatgpt.com/codex/tasks/task_e_68bb98ffa92c8330bee20fd23cefcc00